### PR TITLE
Python-version and list depth issue

### DIFF
--- a/markdown2pdf/__init__.py
+++ b/markdown2pdf/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import os
 import argparse
 

--- a/markdown2pdf/themes/github.css
+++ b/markdown2pdf/themes/github.css
@@ -841,6 +841,10 @@ span.bash-output {
   margin: 0px;
 }
 
+li li {
+	margin-left: 2em;
+}
+
 /* @end */
 
 /****************************/


### PR DESCRIPTION
It's important to specify the `python2`-command since some distributions use `python3` as default python interpreter (symlinked to `python`)

I really like the github theme, but there is no further indentation for the inner list items yet.
