### PR TITLE
Fix: python interpreter should be explicitly set to python2

### DIFF
--- a/markdown2pdf/__init__.py
+++ b/markdown2pdf/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import os
 import argparse
 


### PR DESCRIPTION
Discussion head in #1 

@kxxoling wrote:

> python always means Python 2 and Python 3 should always be python3. This's specified in PEP 0394.

No. For time beeing it **should** refer to python2.

Furthermore PEP 0394 says:

> in preparation for an eventual change in the default version of Python, Python 2 only scripts should either be updated to be source compatible with Python 3 or else to use python2 in the shebang line.

ArchLinux has already done this step.
